### PR TITLE
Allow a user specified CSS variable to override the hex color of statusBar only

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ body.dark {
 }
 ```
 
-> 👉🏽 **Note:** The `syncStatusBar` feature relies on the presence of the `--backgound` CSS variable, which contains the background color of the body. If you are using custom dark mode CSS, you will need to add that variable to your CSS. The variable must be a regular hex color. If your `--background` CSS variable contains anything else (like a gradient for example), pass a different CSS variable name to init() as the member `statusBarHexColorCssVariable` and it will take preference over `--background`. It must be a regular hex color.
+> 👉🏽 **Note:** The `syncStatusBar` feature relies on the presence of the `--backgound` CSS variable, which contains the background color of the body. If you are using custom dark mode CSS, you will need to add that variable to your CSS. The variable must be a regular hex color. If your `--background` CSS variable contains anything else (like a gradient for example), pass a different CSS variable name to init() in the options member `statusBarHexColorCssVariable` and it will take preference over `--background`. It must be a regular hex color.
 
 ### Plugin configuration
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ body.dark {
 }
 ```
 
-> 👉🏽 **Note:** The `syncStatusBar` feature relies on the presence of the `--backgound` CSS variable, which contains the background color of the body. If you are using custom dark mode CSS, you will need to add that variable to your CSS. The variable must be a regular hex color. If your `--background` CSS variable contains anything else (like a gradient for example), you can use the variable `--statusBarBackground` which will take preference. It must be a regular hex color.
+> 👉🏽 **Note:** The `syncStatusBar` feature relies on the presence of the `--backgound` CSS variable, which contains the background color of the body. If you are using custom dark mode CSS, you will need to add that variable to your CSS. The variable must be a regular hex color. If your `--background` CSS variable contains anything else (like a gradient for example), pass a different CSS variable name to init() as the member `statusBarHexColorCssVariable` and it will take preference over `--background`. It must be a regular hex color.
 
 ### Plugin configuration
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ body.dark {
 }
 ```
 
-> 👉🏽 **Note:** The `syncStatusBar` feature relies on the presence of the `--backgound` CSS variable, which contains the background color of the body. If you are using custom dark mode CSS, you will need to add that variable to your CSS.
+> 👉🏽 **Note:** The `syncStatusBar` feature relies on the presence of the `--backgound` CSS variable, which contains the background color of the body. If you are using custom dark mode CSS, you will need to add that variable to your CSS. The variable must be a regular hex color. If your `--background` CSS variable contains anything else (like a gradient for example), you can use the variable `--statusBarBackground` which will take preference. It must be a regular hex color.
 
 ### Plugin configuration
 

--- a/android/src/main/java/com/aparajita/capacitor/darkmode/DarkModeNative.java
+++ b/android/src/main/java/com/aparajita/capacitor/darkmode/DarkModeNative.java
@@ -1,7 +1,6 @@
 package com.aparajita.capacitor.darkmode;
 
 import android.content.res.Configuration;
-
 import com.getcapacitor.*;
 import com.getcapacitor.annotation.CapacitorPlugin;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aparajita/capacitor-dark-mode",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Universal dark mode support for Ionic web and native apps",
   "author": "Aparajita Fishman",
   "license": "MIT",

--- a/src/base.ts
+++ b/src/base.ts
@@ -35,6 +35,7 @@ export default abstract class DarkModeBase
 {
   private appearance?: DarkModeAppearance
   private darkModeClass = 'dark'
+  private statusBarHexColorCssVariable = ''
   protected registeredListener = false
   private readonly appearanceListeners = new Set<DarkModeListener>()
   private getter?: DarkModeGetter
@@ -61,12 +62,17 @@ export default abstract class DarkModeBase
   async init({
     cssClass,
     getter,
-    syncStatusBar
+    syncStatusBar,
+    statusBarHexColorCssVariable
   }: DarkModeOptions = {}): Promise<void> {
     if (cssClass) {
       // Remove the old class if it exists
       document.documentElement.classList.remove(this.darkModeClass)
       this.darkModeClass = cssClass
+    }
+
+    if (statusBarHexColorCssVariable) {
+      this.statusBarHexColorCssVariable = statusBarHexColorCssVariable
     }
 
     if (typeof getter !== 'undefined') {
@@ -162,7 +168,7 @@ export default abstract class DarkModeBase
 
       if (content) {
         const overrideBodyBackgroundColor = getComputedStyle(content)
-        .getPropertyValue('--statusBarBackground')
+        .getPropertyValue(this.statusBarHexColorCssVariable)
         .trim()
 
         // or fallback to regular --background

--- a/src/base.ts
+++ b/src/base.ts
@@ -167,14 +167,15 @@ export default abstract class DarkModeBase
       const content = document.querySelector('ion-content')
 
       if (content) {
-        const overrideBodyBackgroundColor = getComputedStyle(content)
+        const statusBarBackground = getComputedStyle(content)
           .getPropertyValue(this.statusBarHexColorCssVariable)
           .trim()
 
-        // or fallback to regular --background
-        const bodyBackgroundColor =
-          overrideBodyBackgroundColor ||
-          getComputedStyle(content).getPropertyValue('--background').trim()
+        const contentBackground = getComputedStyle(content)
+          .getPropertyValue('--background')
+          .trim()
+
+        const bodyBackgroundColor = statusBarBackground || contentBackground
 
         if (bodyBackgroundColor) {
           if (this.syncStatusBar !== 'textOnly') {

--- a/src/base.ts
+++ b/src/base.ts
@@ -168,13 +168,13 @@ export default abstract class DarkModeBase
 
       if (content) {
         const overrideBodyBackgroundColor = getComputedStyle(content)
-        .getPropertyValue(this.statusBarHexColorCssVariable)
-        .trim()
+          .getPropertyValue(this.statusBarHexColorCssVariable)
+          .trim()
 
         // or fallback to regular --background
-        const bodyBackgroundColor = overrideBodyBackgroundColor || getComputedStyle(content)
-          .getPropertyValue('--background')
-          .trim()
+        const bodyBackgroundColor =
+          overrideBodyBackgroundColor ||
+          getComputedStyle(content).getPropertyValue('--background').trim()
 
         if (bodyBackgroundColor) {
           if (this.syncStatusBar !== 'textOnly') {

--- a/src/base.ts
+++ b/src/base.ts
@@ -161,7 +161,12 @@ export default abstract class DarkModeBase
       const content = document.querySelector('ion-content')
 
       if (content) {
-        const bodyBackgroundColor = getComputedStyle(content)
+        const overrideBodyBackgroundColor = getComputedStyle(content)
+        .getPropertyValue('--statusBarBackground')
+        .trim()
+
+        // or fallback to regular --background
+        const bodyBackgroundColor = overrideBodyBackgroundColor || getComputedStyle(content)
           .getPropertyValue('--background')
           .trim()
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -86,7 +86,7 @@ export interface DarkModeOptions {
    * On iOS this option is not used, the status bar background
    * is synced with dark mode by the system.
    */
-  syncStatusBar?: DarkModeSyncStatusBar,
+  syncStatusBar?: DarkModeSyncStatusBar
 
   /**
    * If set, on Android the status bar BACKGROUND hex color
@@ -96,7 +96,7 @@ export interface DarkModeOptions {
    * On iOS this option is not used, the status bar background
    * is synced with dark mode by the system.
    */
-  statusBarHexColorCssVariable?: string,
+  statusBarHexColorCssVariable?: string
 }
 
 /**

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -86,7 +86,17 @@ export interface DarkModeOptions {
    * On iOS this option is not used, the status bar background
    * is synced with dark mode by the system.
    */
-  syncStatusBar?: DarkModeSyncStatusBar
+  syncStatusBar?: DarkModeSyncStatusBar,
+
+  /**
+   * If set, on Android the status bar BACKGROUND hex color
+   * will be read from this CSS variable.
+   *
+   *
+   * On iOS this option is not used, the status bar background
+   * is synced with dark mode by the system.
+   */
+  statusBarHexColorCssVariable?: string,
 }
 
 /**


### PR DESCRIPTION
- User can set a specific (ion-content) CSS variable to apply to statusbar background
- Automatically calculates the threshold color and sets statusbar style (=text color) to white or black depending on background color applied

formula approximately from https://stackoverflow.com/questions/596216/formula-to-determine-perceived-brightness-of-rgb-color