### PR TITLE
run getter every time, not only on init

### DIFF
--- a/android/src/main/java/com/aparajita/capacitor/darkmode/DarkModeNative.java
+++ b/android/src/main/java/com/aparajita/capacitor/darkmode/DarkModeNative.java
@@ -1,7 +1,6 @@
 package com.aparajita.capacitor.darkmode;
 
 import android.content.res.Configuration;
-
 import com.getcapacitor.*;
 import com.getcapacitor.annotation.CapacitorPlugin;
 

--- a/android/src/main/java/com/aparajita/capacitor/darkmode/DarkModeNative.java
+++ b/android/src/main/java/com/aparajita/capacitor/darkmode/DarkModeNative.java
@@ -1,6 +1,7 @@
 package com.aparajita.capacitor.darkmode;
 
 import android.content.res.Configuration;
+
 import com.getcapacitor.*;
 import com.getcapacitor.annotation.CapacitorPlugin;
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -167,7 +167,6 @@ export default abstract class DarkModeBase
       // Note at this point, this.isDark is the previous dark mode.
       darkMode = this.appearance === DarkModeAppearance.dark
     }
-    // }
 
     this.disableTransitions()
     document.body.classList[darkMode ? 'add' : 'remove'](this.darkModeClass)

--- a/src/base.ts
+++ b/src/base.ts
@@ -147,26 +147,27 @@ export default abstract class DarkModeBase
       // If we have data, that means the system appearance changed.
       // Use it to determine the new dark mode.
       darkMode = data.dark
-    } else {
-      if (this.getter) {
-        // The user changed the appearance and triggered an update,
-        // so we need to get the new appearance.
-        const getterResult = await this.getter()
+    }
 
-        if (getterResult) {
-          this.appearance = getterResult
-        }
-      }
+    if (this.getter) {
+      // The user changed the appearance and triggered an update,
+      // so we need to get the new appearance.
+      const getterResult = await this.getter()
 
-      // If the appearance changed and is system, get the current dark mode.
-      if (this.appearance === DarkModeAppearance.system) {
-        darkMode = (await this.isDarkMode()).dark
-      } else {
-        // Otherwise, use the new appearance to determine the dark mode.
-        // Note at this point, this.isDark is the previous dark mode.
-        darkMode = this.appearance === DarkModeAppearance.dark
+      if (getterResult) {
+        this.appearance = getterResult
       }
     }
+
+    // If the appearance changed and is system, get the current dark mode.
+    if (this.appearance === DarkModeAppearance.system) {
+      darkMode = (await this.isDarkMode()).dark
+    } else {
+      // Otherwise, use the new appearance to determine the dark mode.
+      // Note at this point, this.isDark is the previous dark mode.
+      darkMode = this.appearance === DarkModeAppearance.dark
+    }
+    // }
 
     this.disableTransitions()
     document.body.classList[darkMode ? 'add' : 'remove'](this.darkModeClass)


### PR DESCRIPTION
In 3.3.1, the getter() function is run only on init.

But on the next device darkmode switch event it isn't checked, so update() just follows whatever incoming data = incoming dark/light mode = not respecting user preference.

In current 3.1.1, even setting getter permanently to 'light' doesn't work - the darkmode always follows system mode anyway:
 ```js
 import {
  DarkMode,
  DarkModeAppearance
} from '@aparajita/capacitor-dark-mode';

...

 DarkMode.init({
      syncStatusBar: true,
      statusBarBackgroundVariable: '--statusBarBackground', // must be set on ion-content
      getter: () => DarkModeAppearance.light,
      // getter: this.getAppearancePref,
    });
 ```
I propose moving the getter logic out of the `if data() ... else {}` block so that it is run on each device darkmode update.